### PR TITLE
Enable Testing for Throws with Helper Function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out
 *.sol*.bin
 chains.json
 .ipfs-develop/
+package-lock.json

--- a/build/addresses/SubmittedPapersIndex.development.json
+++ b/build/addresses/SubmittedPapersIndex.development.json
@@ -1,1 +1,1 @@
-{"address":"0x89d496a492af42e50fe32cc766c1bc9d1dceaa1f"}
+{"address":"0x12b7cbadc60154880c37565e699f420641b35bba"}

--- a/contracts/SubmittedPapersIndex.sol
+++ b/contracts/SubmittedPapersIndex.sol
@@ -4,10 +4,8 @@ contract SubmittedPapersIndex {
   bytes32[] public store;
 
   function push(bytes32 _hash) {
-      //todo: throw an error if empty
-    if(_hash != 0x00){
-      store.push(_hash);
-    }
+    require(_hash != 0x00);
+    store.push(_hash);
   }
 
   function getAll() constant returns (bytes32[] hashes) {

--- a/test/SubmittedPapersIndex.spec.js
+++ b/test/SubmittedPapersIndex.spec.js
@@ -1,4 +1,5 @@
 const EncodingHelper = require('../app/common/encoding-helper')
+const expectThrow = require('../test/helpers/expectThrow')
 // const assert = require('assert')
 console.log('*********', Object.keys(contract))
 
@@ -10,26 +11,25 @@ contract('SubmittedPapersIndex', function (accounts) {
 
   // the contrarct state is not reset between indivdual tests
   // therfore the empty state must be tested before the stored value test
-  it('refuses empty value', function () {
+  it('refuses empty value', async function () {
     const bytesOfAddress = ''
-    return SubmittedPapersIndex.deployed().then((instance)=>{
-      return instance.push(bytesOfAddress).then(() => {
-        return instance.getAll()
-      })
-    }).then((result) => {
-      assert.equal(result[0], null)
-    })
-  })
+    var instance = await SubmittedPapersIndex.deployed();
+    // test for throw with empty value is used in push
+    await expectThrow(
+      instance.push(bytesOfAddress),
+    );
+    const result = await instance.getAll();
 
-  it('set storage value', function () {
+    assert.equal(result[0], null)
+  });
+
+  it('set storage value', async function () {
     const bytesOfAddress = EncodingHelper.ipfsAddressToHexSha256('QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')
-    return SubmittedPapersIndex.deployed().then((instance) => {
-      return instance.push(bytesOfAddress).then(()=>{
-        return instance.getAll()
-      })
-    }).then((result) => {
-      assert.equal(EncodingHelper.hexSha256ToIpfsMultiHash(result[0]), 'QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')
-    })
-  })
+    var instance = await SubmittedPapersIndex.deployed();
+    await instance.push(bytesOfAddress);
+    const result = await instance.getAll();
+
+    assert.equal(EncodingHelper.hexSha256ToIpfsMultiHash(result[0]), 'QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH')
+  });
 
 })

--- a/test/helpers/expectThrow.js
+++ b/test/helpers/expectThrow.js
@@ -1,0 +1,22 @@
+// taken & modified from open-zepplin project
+// https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/test/helpers/expectThrow.js
+module.exports = async promise => {
+  try {
+    await promise;
+  } catch (error) {
+    // TODO: Check jump destination to destinguish between a throw
+    //       and an actual invalid jump.
+    const invalidOpcode = error.message.search('invalid opcode') >= 0;
+    // TODO: When we contract A calls contract B, and B throws, instead
+    //       of an 'invalid jump', we get an 'out of gas' error. How do
+    //       we distinguish this from an actual out of gas event? (The
+    //       testrpc log actually show an 'invalid jump' event.)
+    const outOfGas = error.message.search('out of gas') >= 0;
+    assert(
+      invalidOpcode || outOfGas,
+      "Expected throw, got '" + error + "' instead",
+    );
+    return;
+  }
+  assert.fail('Expected throw not received');
+};


### PR DESCRIPTION
- Implement expectThrow help function from open-zeppelin project
- SubmittedPaperIndex throws on empty input
- Change test to async/await syntax

## I confirm:

- [x] I've read the [contributing guidelines](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CODE-OF-CONDUCT.md)
- [x] I've checked that this issue applies to this repo
- [x] I've checked the existing issues, no one else has reported this
- [x] I've limited the subject line to 50 characters 
- [x] I've capitalised the subject line
- [x] I've not ended the subject line with a period
- [x] I've used the imperative mood in the subject line 

---------------------------

### Making an enhancement - ignore this if not making an enhancement

- [ ] I've **Checked** the [outstanding issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Aaletheia-foundation+). 
- [ ] I've **Read** the latest version of the [whitepaper](https://github.com/aletheia-foundation/whitepaper).
- [ ] I've **Emailed** contact@aletheia-foundation.io to discuss the enhancement. 
