### PR TITLE
NPM 'IPFS-LOCAL' TASK SUPPORTED CROSS PLATFORM

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "startOld": "./node_modules/.bin/truffle migrate && electron .",
     "testOld": "./node_modules/.bin/truffle test && ./node_modules/.bin/truffle migrate && mocha",
     "ethereum-local": "testrpc",
-    "ipfs-local": "./scripts/ipfs-local.sh",
+    "ipfs-local": "node ./scripts/ipfs-local.js",
     "ethereum-testnet": "./scripts/start-geth-testnet.sh",
     "ethereum-testnet:attach": "./scripts/attach-geth-testnet.sh",
     "ng": "ng",

--- a/scripts/ipfs-local.js
+++ b/scripts/ipfs-local.js
@@ -1,0 +1,28 @@
+const child_process = require('child_process');
+const fs = require('fs');
+
+const devPath = ".ipfs-develop";
+
+let isWin = /^win/.test(process.platform);
+
+let shell = (cmd, callback) => {
+  let child = child_process.exec(cmd, callback);
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+  process.stdin.pipe(child.stdin);
+}
+
+let runIpfs = () => {
+  shell (`ipfs daemon -c ${devPath}`);
+}
+
+let initDev = !fs.existsSync(devPath);
+
+if(initDev) {
+  shell (`ipfs init -c ${devPath}`, (err, stdout, stderr) => {
+    if(!err) runIpfs();
+  });
+} else {
+  runIpfs();
+}
+


### PR DESCRIPTION
The npm task "ipfs-local" previously ran a bash script, which is not supported in Windows.

I have created a node script, which I have tested on Windows 10 and Ubuntu 16.04. This uses node's "child_process" module to start IPFS

Part of : #69 


## I confirm:

- [x] I've read the [contributing guidelines](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/aletheia-foundation/aletheia-admin/blob/master/CODE-OF-CONDUCT.md)
- [x] I've checked that this issue applies to this repo
- [x] I've checked the existing issues, no one else has reported this
- [x] I've limited the subject line to 50 characters 
- [x] I've capitalised the subject line
- [x] I've not ended the subject line with a period
- [x] I've used the imperative mood in the subject line 

---------------------------

### Making an enhancement - ignore this if not making an enhancement

- [x] I've **Checked** the [outstanding issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+user%3Aaletheia-foundation+). 
- [x] I've **Read** the latest version of the [whitepaper](https://github.com/aletheia-foundation/whitepaper).
- [x] I've **Emailed** contact@aletheia-foundation.io to discuss the enhancement. 
